### PR TITLE
Fix template module

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,11 @@ jobs:
           name: Smoke Test Install
           command: |
             python --version
-            sudo pip3 install .
+            REPO_DIR="${PWD}"
+            cd "$(mktemp -d)"
+            sudo pip3 install "${REPO_DIR}"
+            fyoo --set=lib=fyoo -- pip show '{{ lib }}'
+            python3 -m fyoo -- echo "Today is {{ date() }}"
   deploy:
     docker:
       - image: circleci/python:3.7


### PR DESCRIPTION
This adds a required __init__.py file. This also adds a rudimentary check on "Smoke Install" to not simply use the current python path, and actually try installing fyoo from an external folder.